### PR TITLE
Update Readme Due to Prisma Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before we start, let's install Prisma and `next-auth` into the Next.js project.
 ```
 npm i next-auth
 
-npm i -D @prisma/cli @types/next-auth
+npm i -D @prisma/cli@2.12.0 @types/next-auth
 ```
 
 _I'm using TypeScript in this tutorial, so I'll also install the type definitions for `next-auth`_


### PR DESCRIPTION
It looks like Prisma updated its migration behavior. Normally upgrading wouldn't be an issue, but the updated migrate flow does not work in Heroku due to a permissions problem. Further, upgrading to 2.13.0 blocks legacy migrate flow. A simple fix is to hold the prisma/cli @ 2.12 until either is fixed. You can get technically get around this with `prisma db push --preview-feature`, but that doesn't generate nice looking schema. Thanks for the tutorial!

[Legacy Flow](https://www.prisma.io/docs/concepts/components/prisma-migrate/legacy-migrate)
[New Flows](https://www.prisma.io/docs/concepts/components/prisma-migrate/prisma-migrate-flows)
[db push](https://www.prisma.io/docs/reference/api-reference/command-reference#db)